### PR TITLE
Fix API helper usage and disable unfinished UI

### DIFF
--- a/client/src/components/advanced-interpolation.tsx
+++ b/client/src/components/advanced-interpolation.tsx
@@ -255,23 +255,9 @@ export function AdvancedInterpolation({ onSettingsChange }: AdvancedInterpolatio
             </div>
 
             {/* Connection Test */}
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  // TODO: Implement connection test
-                  console.log("Testing AI server connection...");
-                }}
-                disabled={!aiServerIP || !aiServerPort}
-              >
-                Test Connection
-              </Button>
-              {aiServerIP && aiServerPort && (
-                <Badge variant="secondary" className="text-xs">
-                  {aiServerIP}:{aiServerPort}
-                </Badge>
-              )}
+            <div className="text-xs text-muted-foreground">
+              Connection testing will be available once the external AI bridge is ready.
+              For now, ensure your Stable Diffusion endpoint is reachable manually before enabling AI upscaling.
             </div>
           </CardContent>
         )}

--- a/client/src/components/ai-texture-generator.tsx
+++ b/client/src/components/ai-texture-generator.tsx
@@ -100,18 +100,15 @@ export default function AITextureGenerator() {
     
     try {
       // Call the AI generation API
-      const response = await apiRequest('/api/ai/generate-texture', {
-        method: 'POST',
-        body: JSON.stringify({
-          prompt,
-          negativePrompt,
-          style,
-          resolution: parseInt(resolution),
-          variations,
-          seed: seed || Math.floor(Math.random() * 1000000)
-        })
+      const response = await apiRequest("POST", "/api/ai/generate-texture", {
+        prompt,
+        negativePrompt,
+        style,
+        resolution: parseInt(resolution),
+        variations,
+        seed: seed || Math.floor(Math.random() * 1000000)
       });
-      
+
       const data = await response.json();
       setGeneratedImages(data.images || []);
       toast({ 

--- a/client/src/components/batch-processor.tsx
+++ b/client/src/components/batch-processor.tsx
@@ -65,84 +65,10 @@ export default function BatchProcessor() {
   });
 
   const startProcessing = async () => {
-    setIsProcessing(true);
-    setIsPaused(false);
-    
-    try {
-      // Create a new conversion job for the batch
-      const response = await apiRequest('/api/jobs', {
-        method: 'POST',
-        body: {
-          settings: {
-            outputFormat: 'png',
-            generateMaps: true,
-            compressionLevel: 6,
-            bulkResize: { enabled: false }
-          }
-        }
-      });
-
-      const jobId = response.id;
-
-      for (let i = currentIndex; i < queue.length; i++) {
-        if (isPaused) break;
-        
-        setCurrentIndex(i);
-        const item = queue[i];
-        
-        // Update status to processing
-        setQueue(prev => prev.map((q, idx) => 
-          idx === i ? { ...q, status: 'processing', startTime: Date.now() } : q
-        ));
-        
-        try {
-          // Upload file to the job
-          const formData = new FormData();
-          // Note: We'd need to store the actual File objects in the queue
-          // This is a simplified version - in practice, we'd need to restructure
-          // the queue to store the actual files
-          
-          // For now, simulate real processing time
-          await new Promise(resolve => setTimeout(resolve, 1000 + Math.random() * 2000));
-          
-          // Mark as completed
-          setQueue(prev => prev.map((q, idx) => 
-            idx === i ? { 
-              ...q, 
-              status: 'completed', 
-              progress: 100,
-              endTime: Date.now()
-            } : q
-          ));
-          
-        } catch (error) {
-          console.error(`Failed to process ${item.name}:`, error);
-          setQueue(prev => prev.map((q, idx) => 
-            idx === i ? { 
-              ...q, 
-              status: 'failed', 
-              progress: 100,
-              endTime: Date.now(),
-              error: error instanceof Error ? error.message : 'Processing failed'
-            } : q
-          ));
-        }
-      }
-      
-      if (!isPaused) {
-        setIsProcessing(false);
-        setCurrentIndex(0);
-        toast({ title: "Batch processing complete!" });
-      }
-    } catch (error) {
-      console.error('Failed to start batch processing:', error);
-      setIsProcessing(false);
-      toast({ 
-        title: "Failed to start batch processing", 
-        description: error instanceof Error ? error.message : 'Unknown error',
-        variant: "destructive" 
-      });
-    }
+    toast({
+      title: "Batch processing coming soon",
+      description: "Batch uploads aren't wired up yet. Please convert files individually for now.",
+    });
   };
 
   const pauseProcessing = () => {
@@ -207,6 +133,11 @@ export default function BatchProcessor() {
             Supports PNG, JPG, TIFF, TGA, and ZIP files
           </p>
         </div>
+
+        <p className="text-sm text-muted-foreground">
+          Batch automation is still being wired up. The controls below remain available for preview, but
+          conversions will need to be run individually for now.
+        </p>
 
         {/* Controls */}
         {queue.length > 0 && (

--- a/client/src/components/discord-integration.tsx
+++ b/client/src/components/discord-integration.tsx
@@ -70,12 +70,9 @@ export default function DiscordIntegration({ project, className }: DiscordIntegr
   // Share project mutation
   const shareProjectMutation = useMutation({
     mutationFn: async (data: { userIds: string[], permission: 'view' | 'edit', message?: string }) => {
-      return apiRequest('/api/projects/share', {
-        method: 'POST',
-        body: JSON.stringify({
-          projectId: project.id,
-          ...data
-        })
+      return apiRequest("POST", "/api/projects/share", {
+        projectId: project.id,
+        ...data
       });
     },
     onSuccess: () => {
@@ -99,12 +96,9 @@ export default function DiscordIntegration({ project, className }: DiscordIntegr
   // Generate invite mutation
   const generateInviteMutation = useMutation({
     mutationFn: async (data: { expiresInHours: number }) => {
-      return apiRequest('/api/projects/invite', {
-        method: 'POST',
-        body: JSON.stringify({
-          projectId: project.id,
-          ...data
-        })
+      return apiRequest("POST", "/api/projects/invite", {
+        projectId: project.id,
+        ...data
       });
     },
     onSuccess: () => {
@@ -119,9 +113,7 @@ export default function DiscordIntegration({ project, className }: DiscordIntegr
   // Remove share mutation
   const removeShareMutation = useMutation({
     mutationFn: async (shareId: number) => {
-      return apiRequest(`/api/projects/shares/${shareId}`, {
-        method: 'DELETE'
-      });
+      return apiRequest("DELETE", `/api/projects/shares/${shareId}`);
     },
     onSuccess: () => {
       toast({

--- a/client/src/components/enhanced-project-dashboard.tsx
+++ b/client/src/components/enhanced-project-dashboard.tsx
@@ -180,7 +180,8 @@ export default function EnhancedProjectDashboard({ projectId }: { projectId?: nu
 
     const createProjectMutation = useMutation({
       mutationFn: async (data: { name: string; description: string }) => {
-        return apiRequest('/api/projects', { method: 'POST', body: data });
+        const response = await apiRequest("POST", "/api/projects", data);
+        return response.json() as Promise<Project>;
       },
       onSuccess: (newProject: Project) => {
         toast({ title: "Project created successfully" });

--- a/client/src/components/favorites-panel.tsx
+++ b/client/src/components/favorites-panel.tsx
@@ -60,7 +60,7 @@ export default function FavoritesPanel({ onNavigateToSection, currentSection }: 
       sectionId: string;
       order: number;
     }) => {
-      await apiRequest("/api/favorites", "POST", data);
+      await apiRequest("POST", "/api/favorites", data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/favorites"] });
@@ -83,7 +83,7 @@ export default function FavoritesPanel({ onNavigateToSection, currentSection }: 
   // Remove favorite mutation
   const removeFavoriteMutation = useMutation({
     mutationFn: async (favoriteId: number) => {
-      await apiRequest(`/api/favorites/${favoriteId}`, "DELETE");
+      await apiRequest("DELETE", `/api/favorites/${favoriteId}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/favorites"] });
@@ -104,7 +104,7 @@ export default function FavoritesPanel({ onNavigateToSection, currentSection }: 
   // Reorder favorites mutation
   const reorderMutation = useMutation({
     mutationFn: async (updates: { id: number; order: number }[]) => {
-      await apiRequest("/api/favorites/reorder", "POST", { updates });
+      await apiRequest("POST", "/api/favorites/reorder", { updates });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/favorites"] });

--- a/client/src/components/mobile-discord-share.tsx
+++ b/client/src/components/mobile-discord-share.tsx
@@ -58,13 +58,10 @@ export default function MobileDiscordShare({ project }: MobileDiscordShareProps)
   // Share project mutation
   const shareProjectMutation = useMutation({
     mutationFn: async (data: { userId: string, permission: 'view' | 'edit' }) => {
-      return apiRequest('/api/projects/share', {
-        method: 'POST',
-        body: JSON.stringify({
-          projectId: project.id,
-          userIds: [data.userId],
-          permission: data.permission
-        })
+      return apiRequest("POST", "/api/projects/share", {
+        projectId: project.id,
+        userIds: [data.userId],
+        permission: data.permission
       });
     },
     onSuccess: () => {
@@ -88,12 +85,9 @@ export default function MobileDiscordShare({ project }: MobileDiscordShareProps)
   // Generate invite mutation
   const generateInviteMutation = useMutation({
     mutationFn: async () => {
-      return apiRequest('/api/projects/invite', {
-        method: 'POST',
-        body: JSON.stringify({
-          projectId: project.id,
-          expiresInHours: 168 // 1 week
-        })
+      return apiRequest("POST", "/api/projects/invite", {
+        projectId: project.id,
+        expiresInHours: 168 // 1 week
       });
     },
     onSuccess: () => {

--- a/client/src/components/presets-manager.tsx
+++ b/client/src/components/presets-manager.tsx
@@ -65,7 +65,7 @@ export default function PresetsManager({
       settings: any;
       isDefault: boolean;
     }) => {
-      await apiRequest("/api/presets", "POST", data);
+      await apiRequest("POST", "/api/presets", data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/presets"] });
@@ -90,7 +90,7 @@ export default function PresetsManager({
   // Delete preset mutation
   const deletePresetMutation = useMutation({
     mutationFn: async (presetId: number) => {
-      await apiRequest(`/api/presets/${presetId}`, "DELETE");
+      await apiRequest("DELETE", `/api/presets/${presetId}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/presets"] });
@@ -111,7 +111,7 @@ export default function PresetsManager({
   // Set default preset mutation
   const setDefaultMutation = useMutation({
     mutationFn: async (presetId: number) => {
-      await apiRequest(`/api/presets/${presetId}/default`, "POST");
+      await apiRequest("POST", `/api/presets/${presetId}/default`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/presets"] });

--- a/client/src/components/project-share-dialog.tsx
+++ b/client/src/components/project-share-dialog.tsx
@@ -27,10 +27,10 @@ export default function ProjectShareDialog({ projectId, projectName }: ProjectSh
 
   const generateInviteMutation = useMutation({
     mutationFn: async () => {
-      return apiRequest(`/api/projects/${projectId}/invite`, {
-        method: 'POST',
-        body: { expiresInHours: parseInt(expiresInHours) }
+      const response = await apiRequest("POST", `/api/projects/${projectId}/invite`, {
+        expiresInHours: parseInt(expiresInHours)
       });
+      return response.json();
     },
     onSuccess: (data) => {
       setInviteData(data);

--- a/client/src/pages/join-project.tsx
+++ b/client/src/pages/join-project.tsx
@@ -19,9 +19,8 @@ export default function JoinProject() {
 
   const joinProjectMutation = useMutation({
     mutationFn: async (inviteCode: string) => {
-      return apiRequest(`/api/projects/join/${inviteCode}`, {
-        method: 'POST'
-      });
+      const response = await apiRequest("POST", `/api/projects/join/${inviteCode}`);
+      return response.json();
     },
     onSuccess: (data) => {
       setProjectData(data.project);


### PR DESCRIPTION
## Summary
- update apiRequest usage across sharing, presets, favorites, and AI tooling so requests send the right payloads and parse responses
- remove the fake "test connection" button and add messaging that batch automation is still in progress
- ensure the join project flow handles the API response correctly and keeps dialogs functional

## Testing
- npm run check *(fails: existing TypeScript errors in legacy demo files)*

------
https://chatgpt.com/codex/tasks/task_e_68de2d026a04832d8ff794b74eb02482