### PR TITLE
Fix processing status updates discarding prior logs

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,13 +18,18 @@ const zipHandler = new ZipHandler();
 async function processFileAsync(jobId: number, fileBuffer: Buffer, settings: ConversionSettings) {
   const updateStatus = async (updates: Partial<ProcessingStatus>) => {
     const currentStatus = await storage.getProcessingStatus(jobId);
-    if (currentStatus) {
-      await storage.updateProcessingStatus(jobId, {
-        ...currentStatus,
-        ...updates,
-        elapsedTime: currentStatus.elapsedTime + 1000
-      });
-    }
+    if (!currentStatus) return;
+
+    const mergedLogs = updates.logs
+      ? [...(currentStatus.logs ?? []), ...updates.logs]
+      : currentStatus.logs;
+
+    await storage.updateProcessingStatus(jobId, {
+      ...currentStatus,
+      ...updates,
+      logs: mergedLogs,
+      elapsedTime: (currentStatus.elapsedTime ?? 0) + 1000
+    });
   };
 
   try {


### PR DESCRIPTION
## Summary
- merge new processing status log entries with the previous log history instead of replacing it
- keep updating elapsed time even when the existing status lacks a value

## Testing
- npm run check *(fails: pre-existing JSX syntax errors in client/src/components/grow-btn.tsx, client/src/pages/docs-old.tsx, server/routes-old.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68de2cb78910832d896387d8081f69a6